### PR TITLE
Discovered much easier way of getting device and resetting

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,29 +1,15 @@
-#define _GNU_SOURCE
 #include <libusb-1.0/libusb.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <sys/ioctl.h>
-#include <linux/usbdevice_fs.h>
-
-
 
 #define LOGI_VENDOR 0x046d
 #define LOGI_PRODUCT 0xc52b
 
 int main(){
-	libusb_context *ctx;
 	int err = 0;
-	struct libusb_device **list;
-	struct libusb_device_descriptor desc;
-	ssize_t num_devs;
+	libusb_context *ctx;
+	libusb_device_handle *logi_h;
 	libusb_device *logi;
-	uint8_t bnum, dnum; 
-	char *devpath;
 
 	err = libusb_init(&ctx);
 	if(err){
@@ -33,49 +19,19 @@ int main(){
 
 	printf("libusb initialized, finding device\n");
 
-	num_devs = libusb_get_device_list(ctx, &list);
-
-	for (int i = 0; i< num_devs; i++){
-		logi = list[i];
-		libusb_get_device_descriptor(logi, &desc);
-		if (desc.idVendor == LOGI_VENDOR && desc.idProduct == LOGI_PRODUCT)
-			break;
-		logi = NULL; //if the device is not found, the dev pointer will be null
-	}
-
-	if (logi == NULL) {
-		fprintf(stderr, "failed to find transciever\n");
+	logi_h = libusb_open_device_with_vid_pid(ctx, LOGI_VENDOR, LOGI_PRODUCT);
+	if (logi_h == NULL) {
+		fprintf(stderr, "Failed to find device\n");
 		return EXIT_FAILURE;
 	}
 
-	printf("Device found, getting bus information\n");
+	printf("Found device, resetting\n");
 
-	bnum = libusb_get_bus_number(logi);
-	dnum = libusb_get_device_address(logi);
-
-	asprintf(&devpath, "/dev/bus/usb/%0.3hhi/%0.3hhi",bnum,dnum);
-
-	printf("Device found at %s\n", devpath);
-
-	int fd;
-	fd = open(devpath, O_WRONLY);
-	if (fd < 0) {
-		perror("Error opening device file");
+	if (libusb_reset_device(logi_h) != 0){
+		fprintf(stderr, "Failed to reset device\n");
 		return EXIT_FAILURE;
 	}
 
-	int rc;
-	printf("resetting Logitech Transciever\n");
-	rc = ioctl(fd, USBDEVFS_RESET, 0);
-	if (rc < 0){
-		perror("reset ioctl failed");
-		return EXIT_FAILURE;
-	}
-
-	//cleanup
-	close(fd);
-	free(devpath);
-	libusb_free_device_list(list,0);
 	libusb_exit(ctx);
 
 	printf("Reset successful?\n");


### PR DESCRIPTION
libusb turns out to have a function that opens based on
vendor and product id, and it also has a dedicated reset
function as well. This dramaticall reduces the complexity
of the program.